### PR TITLE
[fix] tests/training loads loader_kwargs from imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ docstring-code-format = true
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-vv"
+addopts = "-vv --import-mode=importlib"
 filterwarnings = [
     "ignore::UserWarning:Precision 16-mixed is not supported by the model summary*",
     "ignore::DeprecationWarning:This process * is multi-threaded, use of fork() may lead to deadlocks in the child.",

--- a/src/lycil/data/hfmodule.py
+++ b/src/lycil/data/hfmodule.py
@@ -24,6 +24,7 @@ class HFDataModule(L.LightningDataModule):
     def __init__(
         self,
         path: str,
+        *,
         dataset_kwargs: dict | None = None,
         num_tasks: int | None = None,
         num_classes_per_task: int | list[int] | None = None,

--- a/tests/training/constants.py
+++ b/tests/training/constants.py
@@ -1,0 +1,10 @@
+# dataset constants
+CIFAR10_PATH = "data/cifar10"
+CIFAR10_LABEL_COL = "label"
+
+CIFAR100_PATH = "data/cifar100"
+CIFAR100_LABEL_COL = "fine_label"
+
+# dataloader kwargs
+VAL_LOADER_KWARGS = {"batch_size": 128, "shuffle": False, "num_workers": 10}
+TEST_LOADER_KWARGS = VAL_LOADER_KWARGS

--- a/tests/training/test_constants_import.py
+++ b/tests/training/test_constants_import.py
@@ -1,0 +1,5 @@
+def test_constants_import():
+    from .constants import TEST_LOADER_KWARGS, VAL_LOADER_KWARGS
+
+    assert VAL_LOADER_KWARGS != {}
+    assert TEST_LOADER_KWARGS != {}

--- a/tests/training/test_ewc_cifar.py
+++ b/tests/training/test_ewc_cifar.py
@@ -9,21 +9,28 @@ from lycil.constants import _EXP_NAME
 from lycil.data.hfmodule import HFDataModule
 from lycil.learner.ewc import EWC
 
+from .constants import (
+    CIFAR10_LABEL_COL,
+    CIFAR10_PATH,
+    CIFAR100_LABEL_COL,
+    CIFAR100_PATH,
+    TEST_LOADER_KWARGS,
+    VAL_LOADER_KWARGS,
+)
+
 
 @pytest.mark.slow
 @pytest.mark.runs_on(["cuda"])
 @pytest.mark.xdist_group("training")
 def test_ewc_cifar100(device: str, is_dummy_training: bool):
     if is_dummy_training:
-        DATAPATH = "data/cifar10"
+        DATAPATH, LABEL_COL = CIFAR10_PATH, CIFAR10_LABEL_COL
         N_CLASS_PER_TASK = [1, 1]
-        LABEL_COL = "label"
         EPOCHS_PER_TASK = 1
         USE_PRETRAIN_WEIGHTS = False
     else:
-        DATAPATH = "data/cifar100"
+        DATAPATH, LABEL_COL = CIFAR100_PATH, CIFAR100_LABEL_COL
         N_CLASS_PER_TASK = [20, 20, 20, 20, 20]
-        LABEL_COL = "fine_label"
         EPOCHS_PER_TASK = 80
         USE_PRETRAIN_WEIGHTS = True
     if not osp.exists(DATAPATH):
@@ -37,8 +44,8 @@ def test_ewc_cifar100(device: str, is_dummy_training: bool):
         num_classes_per_task=N_CLASS_PER_TASK,
         label_column_name=LABEL_COL,  # 100 classes
         train_loader_kwargs={"batch_size": 128, "shuffle": True, "num_workers": 10},
-        val_loader_kwargs={"batch_size": 128, "shuffle": False, "num_workers": 10},
-        test_loader_kwargs={"shuffle": False, "num_workers": 10},
+        val_loader_kwargs=VAL_LOADER_KWARGS,
+        test_loader_kwargs=TEST_LOADER_KWARGS,
         split_map={"train": "test", "val": "test"}
         if EPOCHS_PER_TASK == 1
         else {"val": "test"},

--- a/tests/training/test_icarl_cifar.py
+++ b/tests/training/test_icarl_cifar.py
@@ -9,6 +9,15 @@ from lycil.constants import _EXP_NAME
 from lycil.data.hfmodule import HFDataModule
 from lycil.learner.icarl import ICaRL
 
+from .constants import (
+    CIFAR10_LABEL_COL,
+    CIFAR10_PATH,
+    CIFAR100_LABEL_COL,
+    CIFAR100_PATH,
+    TEST_LOADER_KWARGS,
+    VAL_LOADER_KWARGS,
+)
+
 BUFFER_SIZE_PER_CLASS = 20
 
 
@@ -17,15 +26,13 @@ BUFFER_SIZE_PER_CLASS = 20
 @pytest.mark.xdist_group("training")
 def test_icarl_cifar100(device: str, is_dummy_training: bool):
     if is_dummy_training:
-        DATAPATH = "data/cifar10"
+        DATAPATH, LABEL_COL = CIFAR10_PATH, CIFAR10_LABEL_COL
         N_CLASS_PER_TASK = [1, 1]
-        LABEL_COL = "label"
         EPOCHS_PER_TASK = 1
         USE_PRETRAIN_WEIGHTS = False
     else:
-        DATAPATH = "data/cifar100"
+        DATAPATH, LABEL_COL = CIFAR100_PATH, CIFAR100_LABEL_COL
         N_CLASS_PER_TASK = [20, 20, 20, 20, 20]
-        LABEL_COL = "fine_label"
         EPOCHS_PER_TASK = 80
         USE_PRETRAIN_WEIGHTS = True
     if not osp.exists(DATAPATH):
@@ -39,8 +46,8 @@ def test_icarl_cifar100(device: str, is_dummy_training: bool):
         num_classes_per_task=N_CLASS_PER_TASK,
         label_column_name=LABEL_COL,  # 100 classes
         train_loader_kwargs={"batch_size": 64, "shuffle": True, "num_workers": 10},
-        val_loader_kwargs={"shuffle": False, "num_workers": 10},
-        test_loader_kwargs={"shuffle": False, "num_workers": 10},
+        val_loader_kwargs=VAL_LOADER_KWARGS,
+        test_loader_kwargs=TEST_LOADER_KWARGS,
         split_map={"train": "test", "val": "test"}
         if EPOCHS_PER_TASK == 1
         else {"val": "test"},

--- a/tests/training/test_lwf_cifar.py
+++ b/tests/training/test_lwf_cifar.py
@@ -9,21 +9,28 @@ from lycil.constants import _EXP_NAME
 from lycil.data.hfmodule import HFDataModule
 from lycil.learner.lwf import LWF
 
+from .constants import (
+    CIFAR10_LABEL_COL,
+    CIFAR10_PATH,
+    CIFAR100_LABEL_COL,
+    CIFAR100_PATH,
+    TEST_LOADER_KWARGS,
+    VAL_LOADER_KWARGS,
+)
+
 
 @pytest.mark.slow
 @pytest.mark.runs_on(["cuda"])
 @pytest.mark.xdist_group("training")
 def test_lwf_cifar100(device: str, is_dummy_training: bool):
     if is_dummy_training:
-        DATAPATH = "data/cifar10"
+        DATAPATH, LABEL_COL = CIFAR10_PATH, CIFAR10_LABEL_COL
         N_CLASS_PER_TASK = [1, 1]
-        LABEL_COL = "label"
         EPOCHS_PER_TASK = 1
         USE_PRETRAIN_WEIGHTS = False
     else:
-        DATAPATH = "data/cifar100"
+        DATAPATH, LABEL_COL = CIFAR100_PATH, CIFAR100_LABEL_COL
         N_CLASS_PER_TASK = [20, 20, 20, 20, 20]
-        LABEL_COL = "fine_label"
         EPOCHS_PER_TASK = 80
         USE_PRETRAIN_WEIGHTS = True
     if not osp.exists(DATAPATH):
@@ -37,8 +44,8 @@ def test_lwf_cifar100(device: str, is_dummy_training: bool):
         num_classes_per_task=N_CLASS_PER_TASK,
         label_column_name=LABEL_COL,  # 100 classes
         train_loader_kwargs={"batch_size": 64, "shuffle": True, "num_workers": 10},
-        val_loader_kwargs={"shuffle": False, "num_workers": 10},
-        test_loader_kwargs={"shuffle": False, "num_workers": 10},
+        val_loader_kwargs=VAL_LOADER_KWARGS,
+        test_loader_kwargs=TEST_LOADER_KWARGS,
         split_map={"train": "test", "val": "test"}
         if EPOCHS_PER_TASK == 1
         else {"val": "test"},

--- a/tests/training/test_ucir_cifar.py
+++ b/tests/training/test_ucir_cifar.py
@@ -9,6 +9,15 @@ from lycil.constants import _EXP_NAME
 from lycil.data.hfmodule import HFDataModule
 from lycil.learner.ucir import UCIR
 
+from .constants import (
+    CIFAR10_LABEL_COL,
+    CIFAR10_PATH,
+    CIFAR100_LABEL_COL,
+    CIFAR100_PATH,
+    TEST_LOADER_KWARGS,
+    VAL_LOADER_KWARGS,
+)
+
 BUFFER_SIZE_PER_CLASS = 20
 
 
@@ -17,15 +26,13 @@ BUFFER_SIZE_PER_CLASS = 20
 @pytest.mark.xdist_group("training")
 def test_ucir_cifar100(device: str, is_dummy_training: bool):
     if is_dummy_training:
-        DATAPATH = "data/cifar10"
+        DATAPATH, LABEL_COL = CIFAR10_PATH, CIFAR10_LABEL_COL
         N_CLASS_PER_TASK = [2, 2]
-        LABEL_COL = "label"
         EPOCHS_PER_TASK = 1
         USE_PRETRAIN_WEIGHTS = False
     else:
-        DATAPATH = "data/cifar100"
+        DATAPATH, LABEL_COL = CIFAR100_PATH, CIFAR100_LABEL_COL
         N_CLASS_PER_TASK = [20, 20, 20, 20, 20]
-        LABEL_COL = "fine_label"
         EPOCHS_PER_TASK = 160
         USE_PRETRAIN_WEIGHTS = True
     if not osp.exists(DATAPATH):
@@ -39,8 +46,8 @@ def test_ucir_cifar100(device: str, is_dummy_training: bool):
         num_classes_per_task=N_CLASS_PER_TASK,
         label_column_name=LABEL_COL,  # 100 classes
         train_loader_kwargs={"batch_size": 512, "shuffle": True, "num_workers": 10},
-        val_loader_kwargs={"shuffle": False, "num_workers": 10},
-        test_loader_kwargs={"shuffle": False, "num_workers": 10},
+        val_loader_kwargs=VAL_LOADER_KWARGS,
+        test_loader_kwargs=TEST_LOADER_KWARGS,
         split_map={"train": "test", "val": "test"}
         if EPOCHS_PER_TASK == 1
         else {"val": "test"},


### PR DESCRIPTION
# What does this PR do?

Training tests now import constants, including data paths, loader kwargs, etc.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/Moenupa/LyCIL/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?